### PR TITLE
Packer release with multiple AMIs

### DIFF
--- a/.github/workflows/packer-release.yml
+++ b/.github/workflows/packer-release.yml
@@ -86,4 +86,4 @@ jobs:
           PKR_VAR_commit_sha: ${{ github.event.head_commit.id }}
           PKR_VAR_repo: ${{ github.repository }}
           PKR_VAR_ami_users: ${{ secrets.ami-users }}
-          PKR_VAR_release_tag: ${{ steps.push_tag.outputs.new_tag }}
+          PKR_VAR_release_tag: ${{ steps.push_tag.outputs.tag }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+## [[0.12.0]](https://github.com/Perform-Partners/github-workflows/releases/tag/v0.12.0)
+### Changed
+* Fix for Packer release when running in a repo with multiple AMIs - [dmitri-pp](https://github.com/dmitri-pp)
 
-## [[0.10.0]](https://github.com/Perform-Partners/github-workflows/releases/tag/v0.10.0)
+## [[0.11.0]](https://github.com/Perform-Partners/github-workflows/releases/tag/v0.11.0)
 ### Added
 * Support for multiple terraform products in one repo - [danw-pp](https://github.com/danw-pp)
+
+## [[0.10.0]](https://github.com/Perform-Partners/github-workflows/releases/tag/v0.10.0)
+### Changed
+* Fix Packer release so that GH tag value is passed to Packer - [dmitri-pp](https://github.com/dmitri-pp)
 
 ## [[0.9.0]](https://github.com/Perform-Partners/github-workflows/releases/tag/v0.9.0)
 ### Added


### PR DESCRIPTION
Fixes the following issue: when running Packer release in a repo with multiple AMIs only one AMI will get its name set to contain Github tag.